### PR TITLE
Add server-side pagination for admin collections table

### DIFF
--- a/app/(admin)/admin/collections/actions.ts
+++ b/app/(admin)/admin/collections/actions.ts
@@ -5,10 +5,14 @@ import prisma from "@/lib/prisma";
 import { UpdateCollectionSchema } from "@/lib/schemas/collection";
 import { formDataToObject } from "@/lib/utils/form-data";
 
-export async function getCollections() {
+export async function getCollections(page: number, limit: number) {
   await requireAdmin();
 
+  const skip = page > 1 ? page * limit : 0;
+
   return prisma.collection.findMany({
+    take: limit,
+    skip,
     select: {
       id: true,
       name: true,

--- a/app/(admin)/admin/collections/actions.ts
+++ b/app/(admin)/admin/collections/actions.ts
@@ -8,20 +8,25 @@ import { formDataToObject } from "@/lib/utils/form-data";
 export async function getCollections(page: number, limit: number) {
   await requireAdmin();
 
-  const skip = page > 1 ? page * limit : 0;
+  const skip = (page - 1) * limit;
 
-  return prisma.collection.findMany({
-    take: limit,
-    skip,
-    select: {
-      id: true,
-      name: true,
-      slug: true,
-      description: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  });
+  const [data, totalCount] = await Promise.all([
+    prisma.collection.findMany({
+      take: limit,
+      skip,
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        description: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    prisma.collection.count(),
+  ]);
+
+  return { data, totalCount };
 }
 
 export async function getCollectionById(id: string) {

--- a/app/(admin)/admin/collections/page.tsx
+++ b/app/(admin)/admin/collections/page.tsx
@@ -6,8 +6,19 @@ import { columns } from "./columns";
 
 export const metadata = { title: "Collections" };
 
-export default async function CollectionsPage() {
-  const collections = await getCollections();
+const limit = 10;
+
+type CollectionsPageProps = {
+  searchParams: {
+    page?: string;
+  };
+};
+
+export default async function CollectionsPage({
+  searchParams,
+}: CollectionsPageProps) {
+  const page = parseInt(searchParams?.page ?? "1");
+  const collections = await getCollections(page, limit);
 
   return (
     <PageContainer>

--- a/app/(admin)/admin/collections/page.tsx
+++ b/app/(admin)/admin/collections/page.tsx
@@ -9,16 +9,17 @@ export const metadata = { title: "Collections" };
 const limit = 10;
 
 type CollectionsPageProps = {
-  searchParams: {
+  searchParams: Promise<{
     page?: string;
-  };
+  }>;
 };
 
 export default async function CollectionsPage({
   searchParams,
 }: CollectionsPageProps) {
-  const page = parseInt(searchParams?.page ?? "1");
-  const { data: collections, totalCount } = await getCollections(page, limit);
+  const pageParam = (await searchParams).page;
+  const page = parseInt(pageParam ?? "1");
+  const { data, totalCount } = await getCollections(page, limit);
   const totalPages = Math.ceil(totalCount / limit);
 
   return (
@@ -26,10 +27,11 @@ export default async function CollectionsPage({
       <PageHeader>Collections</PageHeader>
 
       <DataTable
+        key={page}
         columns={columns}
-        data={collections}
-        currentPage={page}
+        data={data}
         totalPages={totalPages}
+        currentPage={page}
       />
     </PageContainer>
   );

--- a/app/(admin)/admin/collections/page.tsx
+++ b/app/(admin)/admin/collections/page.tsx
@@ -18,13 +18,19 @@ export default async function CollectionsPage({
   searchParams,
 }: CollectionsPageProps) {
   const page = parseInt(searchParams?.page ?? "1");
-  const collections = await getCollections(page, limit);
+  const { data: collections, totalCount } = await getCollections(page, limit);
+  const totalPages = Math.ceil(totalCount / limit);
 
   return (
     <PageContainer>
       <PageHeader>Collections</PageHeader>
 
-      <DataTable columns={columns} data={collections} />
+      <DataTable
+        columns={columns}
+        data={collections}
+        currentPage={page}
+        totalPages={totalPages}
+      />
     </PageContainer>
   );
 }

--- a/app/(admin)/admin/components/ui/data-table.tsx
+++ b/app/(admin)/admin/components/ui/data-table.tsx
@@ -18,22 +18,31 @@ import {
   TableHeader,
   TableRow,
 } from "@/app/(admin)/admin/components/ui/table";
+import type { Table as TanstackTable } from "@tanstack/react-table";
+import { usePathname, useRouter } from "next/navigation";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  currentPage: number;
+  totalPages: number;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
+  currentPage,
+  totalPages,
 }: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
+    manualPagination: true,
   });
+
+  const pathname = usePathname();
+  const router = useRouter();
 
   return (
     <div>
@@ -87,23 +96,28 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-end space-x-2 py-4">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
-        >
-          Previous
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
-        >
-          Next
-        </Button>
+      <div className="flex items-center justify-between space-x-2 py-4">
+        <div className="text-sm text-muted-foreground">
+          Page {currentPage} of {totalPages}
+        </div>
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => router.push(`${pathname}?page=${currentPage - 1}`)}
+            disabled={currentPage <= 1}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => router.push(`${pathname}?page=${currentPage + 1}`)}
+            disabled={currentPage >= totalPages}
+          >
+            Next
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/app/(admin)/admin/components/ui/data-table.tsx
+++ b/app/(admin)/admin/components/ui/data-table.tsx
@@ -5,7 +5,10 @@ import {
   flexRender,
   getCoreRowModel,
   useReactTable,
+  getPaginationRowModel,
 } from "@tanstack/react-table";
+
+import { Button } from "@/app/(admin)/admin/components/ui/button";
 
 import {
   Table,
@@ -29,52 +32,79 @@ export function DataTable<TData, TValue>({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
   });
 
   return (
-    <div className="overflow-hidden rounded-md border">
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows?.length ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id}
-                data-state={row.getIsSelected() && "selected"}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+    <div>
+      <div className="overflow-hidden rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/(admin)/admin/components/ui/data-table.tsx
+++ b/app/(admin)/admin/components/ui/data-table.tsx
@@ -5,7 +5,6 @@ import {
   flexRender,
   getCoreRowModel,
   useReactTable,
-  getPaginationRowModel,
 } from "@tanstack/react-table";
 
 import { Button } from "@/app/(admin)/admin/components/ui/button";
@@ -18,7 +17,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/app/(admin)/admin/components/ui/table";
-import type { Table as TanstackTable } from "@tanstack/react-table";
 import { usePathname, useRouter } from "next/navigation";
 
 interface DataTableProps<TData, TValue> {
@@ -40,9 +38,6 @@ export function DataTable<TData, TValue>({
     getCoreRowModel: getCoreRowModel(),
     manualPagination: true,
   });
-
-  const pathname = usePathname();
-  const router = useRouter();
 
   return (
     <div>
@@ -96,28 +91,43 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-between space-x-2 py-4">
-        <div className="text-sm text-muted-foreground">
-          Page {currentPage} of {totalPages}
-        </div>
-        <div className="flex items-center space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => router.push(`${pathname}?page=${currentPage - 1}`)}
-            disabled={currentPage <= 1}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => router.push(`${pathname}?page=${currentPage + 1}`)}
-            disabled={currentPage >= totalPages}
-          >
-            Next
-          </Button>
-        </div>
+
+      <Pagination currentPage={currentPage} totalPages={totalPages} />
+    </div>
+  );
+}
+
+type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+};
+
+function Pagination({ totalPages, currentPage }: PaginationProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <div className="flex items-center justify-between space-x-2 py-4">
+      <div className="text-sm text-muted-foreground">
+        Page {currentPage} of {totalPages}
+      </div>
+      <div className="flex items-center space-x-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push(`${pathname}?page=${currentPage - 1}`)}
+          disabled={currentPage <= 1}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push(`${pathname}?page=${currentPage + 1}`)}
+          disabled={currentPage >= totalPages}
+        >
+          Next
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adds server-side pagination to the admin collections page and resolves #1. The changes update both the backend data fetching and the frontend table component to support paginated results, including a new pagination UI.

**Backend Pagination Implementation:**

- Modified the `getCollections` function in `actions.ts` to accept `page` and `limit` parameters, returning both the paginated data and the total count of collections for pagination calculations. [[1]](diffhunk://#diff-dcd70c7db867ffdac748bb2e5e4a0f3fc88a3b56279e688113590aabe7513421L8-R16) [[2]](diffhunk://#diff-dcd70c7db867ffdac748bb2e5e4a0f3fc88a3b56279e688113590aabe7513421L20-R29)

**Frontend Pagination Integration:**

- Updated `CollectionsPage` in `page.tsx` to read the current page from `searchParams`, call `getCollections` with pagination parameters, compute the total number of pages, and pass pagination props to the data table.

**Data Table and Pagination UI Enhancements:**

- Enhanced the `DataTable` component to accept `currentPage` and `totalPages` props, and added a new `Pagination` component with "Previous" and "Next" buttons for navigation. The table now uses manual pagination mode. [[1]](diffhunk://#diff-4542b58ad074431197c4937b791a06b18dfc4c121e1c0d428c5f5ac6a5ed7211R20-R43) [[2]](diffhunk://#diff-4542b58ad074431197c4937b791a06b18dfc4c121e1c0d428c5f5ac6a5ed7211L64-R132)
- Imported necessary UI and routing utilities in `data-table.tsx` to support the new pagination controls.